### PR TITLE
Telephony: GSM: remove 'Carrier Settings' regardless of csp_enabled

### DIFF
--- a/src/com/android/phone/GsmUmtsOptions.java
+++ b/src/com/android/phone/GsmUmtsOptions.java
@@ -143,15 +143,14 @@ public class GsmUmtsOptions {
                 log("[CSP] Disabling Operator Selection menu.");
                 mPrefScreen.removePreference(mButtonOperatorSelectionExpand);
             }
-
-            // Read platform settings for carrier settings
-            final boolean isCarrierSettingsEnabled = mPrefActivity.getResources().getBoolean(
-                    R.bool.config_carrier_settings_enable);
-            if (!isCarrierSettingsEnabled) {
-                Preference pref = mPrefScreen.findPreference(BUTTON_CARRIER_SETTINGS_KEY);
-                if (pref != null) {
-                    mPrefScreen.removePreference(pref);
-                }
+        }
+        // Read platform settings for carrier settings
+        final boolean isCarrierSettingsEnabled = mPrefActivity.getResources().getBoolean(
+                R.bool.config_carrier_settings_enable);
+        if (!isCarrierSettingsEnabled) {
+            Preference pref = mPrefScreen.findPreference(BUTTON_CARRIER_SETTINGS_KEY);
+            if (pref != null) {
+                mPrefScreen.removePreference(pref);
             }
         }
         if (!mRemovedAPNExpand) {


### PR DESCRIPTION
Carrier Settings should be removed when config_carrier_settings_enable
is false. csp_enabled has nothing to do with it.

Fixes "Carrier Settings" appearing and crashing when the user clicks
on it.

Change-Id: I31c508f2353eb15a096aa279e71c4be4ce89abb8
